### PR TITLE
Remove coq in favour of nvim-cmp

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -215,6 +215,8 @@
       }
       {
         plugin = nixpkgs.vimPlugins.nvim-cmp;
+        config = builtins.readFile ./nvim/nvim-cmp.lua;
+        type = "lua";
       }
       {
         plugin = nixpkgs.vimPlugins.cmp-nvim-lsp;

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -188,21 +188,6 @@
       }
       {
         plugin = let
-          name = "coq.artifacts";
-          rev = "9c5067a471322c6bb866545e88e5b28c82511865";
-        in
-          nixpkgs.vimUtils.buildVimPlugin {
-            name = name;
-            src = nixpkgs.fetchFromGitHub {
-              owner = "ms-jpq";
-              repo = name;
-              rev = rev;
-              hash = "sha256-BHm7U3pINtYamY7m26I4lQee7ccJ6AcHmYx7j1MRFDA=";
-            };
-          };
-      }
-      {
-        plugin = let
           name = "venv-selector.nvim";
           rev = "2ad34f36d498ff5193ea10f79c87688bd5284172";
         in
@@ -229,8 +214,10 @@
         type = "lua";
       }
       {
-        plugin = nixpkgs.vimPlugins.coq_nvim;
-        config = ''let g:coq_settings = { 'auto_start': 'shut-up', 'xdg': v:true }'';
+        plugin = nixpkgs.vimPlugins.nvim-cmp;
+      }
+      {
+        plugin = nixpkgs.vimPlugins.cmp-nvim-lsp;
       }
       {
         plugin = nixpkgs.vimPlugins.rustaceanvim;

--- a/home-manager/nvim/lspconfig.lua
+++ b/home-manager/nvim/lspconfig.lua
@@ -1,4 +1,4 @@
-local coq = require("coq")
+local nvim_cmp = require("cmp")
 
 -- Using rustaceanvim means we shouldn't set up the LSP for Rust manually.
 -- Similarly csharp_ls is unnecessary given roslyn.nvim
@@ -34,6 +34,8 @@ require("lspconfig")["yamlls"].setup({
 })
 
 local capabilities = vim.lsp.protocol.make_client_capabilities()
+capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
+
 capabilities.textDocument.completion.completionItem.snippetSupport = true
 require("lspconfig")["jsonls"].setup({
 	capabilities = capabilities,
@@ -87,7 +89,8 @@ require("lspconfig")["lua_ls"].setup({
 	},
 })
 
-require("lspconfig").pyright.setup(coq.lsp_ensure_capabilities({
+require("lspconfig").pyright.setup({
+	capabilities = capabilities,
 	handlers = {
 		["textDocument/publishDiagnostics"] = function(...)
 			vim.lsp.diagnostic.on_publish_diagnostics(...)
@@ -97,9 +100,10 @@ require("lspconfig").pyright.setup(coq.lsp_ensure_capabilities({
 			vim.api.nvim_set_current_win(window)
 		end,
 	},
-}))
+})
 
-require("lspconfig").nil_ls.setup(coq.lsp_ensure_capabilities({
+require("lspconfig").nil_ls.setup({
+	capabilities = capabilities,
 	settings = {
 		nix = {
 			flake = {
@@ -107,7 +111,7 @@ require("lspconfig").nil_ls.setup(coq.lsp_ensure_capabilities({
 			},
 		},
 	},
-}))
+})
 
 function ToggleLocList()
 	local winid = vim.fn.getloclist(0, { winid = 0 }).winid

--- a/home-manager/nvim/nvim-cmp.lua
+++ b/home-manager/nvim/nvim-cmp.lua
@@ -1,0 +1,45 @@
+local cmp = require("cmp")
+
+cmp.setup({
+	snippet = {
+		-- REQUIRED - you must specify a snippet engine
+		expand = function(args)
+			vim.snippet.expand(args.body)
+		end,
+	},
+	window = {
+		completion = cmp.config.window.bordered(),
+		documentation = cmp.config.window.bordered(),
+	},
+	mapping = cmp.mapping.preset.insert({
+		["<C-b>"] = cmp.mapping.scroll_docs(-4),
+		["<C-f>"] = cmp.mapping.scroll_docs(4),
+		["<C-Space>"] = cmp.mapping.complete(),
+		["<C-e>"] = cmp.mapping.abort(),
+		["<CR>"] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+	}),
+	sources = cmp.config.sources({
+		{ name = "nvim_lsp" },
+	}, {
+		{ name = "buffer" },
+	}),
+})
+
+-- Use buffer source for `/` and `?` (if you enabled `native_menu`, this won't work anymore).
+cmp.setup.cmdline({ "/", "?" }, {
+	mapping = cmp.mapping.preset.cmdline(),
+	sources = {
+		{ name = "buffer" },
+	},
+})
+
+-- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
+cmp.setup.cmdline(":", {
+	mapping = cmp.mapping.preset.cmdline(),
+	sources = cmp.config.sources({
+		{ name = "path" },
+	}, {
+		{ name = "cmdline" },
+	}),
+	matching = { disallow_symbol_nonprefix_matching = false },
+})


### PR DESCRIPTION
It stopped working one too many times. Don't know if this is functioning yet, but at least it's not violently red on startup. It worked with the Pyright LSP.